### PR TITLE
Manage running snapshot (RepositoryBlameSnapshot) in a separate thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,6 +1014,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "crossbeam-channel",
  "dashmap",
  "gix",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ dashmap = {version = "6.1.0", features=["inline", "rayon"]}
 thread_local = "1.1"
 anyhow = "1.0.99"
 serde_json = "1.0.143"
+crossbeam-channel = "0.5"
 
 [dev-dependencies]
 proptest = "1"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,27 @@
+use crate::blame::{Keyable, LineDiffs, LineNumber};
+use gix::bstr::BString;
+
+#[derive(Debug)]
+pub enum Action<CommitKey>
+where
+    CommitKey: Keyable,
+{
+    AddFile {
+        path: BString,
+        total_lines: LineNumber,
+        cohort: CommitKey,
+    },
+    DeleteFile {
+        path: BString,
+    },
+    RenameFile {
+        old_path: BString,
+        new_path: BString,
+    },
+    ModifyFile {
+        path: BString,
+        line_diffs: LineDiffs<CommitKey>,
+    },
+    FinishCommit,
+    SetCommitId(gix::ObjectId),
+}

--- a/src/file_types.rs
+++ b/src/file_types.rs
@@ -1,0 +1,5 @@
+const allowed_filetypes: [&str] = !include_str!("allowed_filetypes.txt").split("\n").collect();
+
+pub fn is_allowed_filetype(filetype: &str) -> bool {
+    allowed_filetypes.contains(&filetype)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod actions;
 pub mod blame;
 pub mod collectors;
 pub mod formatter;

--- a/src/repo_blame_snapshot.rs
+++ b/src/repo_blame_snapshot.rs
@@ -1,12 +1,12 @@
+use crate::actions::Action;
 use crate::blame::{FileBlame, Keyable, LineDiffs, LineNumber};
 use anyhow::Result;
-use dashmap::DashMap;
+use crossbeam_channel::{Sender, unbounded};
 use gix::bstr::BString;
+use std::collections::HashMap;
+use std::thread::{JoinHandle, spawn};
 
 /// Represents blame information for the entire repository at a specific commit
-/// Uses Dashmap so we can update entries concurrently for a slight boost
-/// Later I'd like to switch to a crossbeam consumer that updates a single threaded map,
-/// I think that would be faster than the coarse locking in the Dashmap.
 /// A CommitKey is a usize that is essentially a pointer into an array of commit info
 #[derive(Debug, Clone)]
 pub struct RepositoryBlameSnapshot<CommitKey>
@@ -14,8 +14,9 @@ where
     CommitKey: Keyable,
 {
     pub commit_id: gix::ObjectId,
-    pub file_blames: DashMap<BString, FileBlame<CommitKey>>,
-    pub running_cohort_stats: DashMap<CommitKey, i64>,
+    pub file_blames: HashMap<BString, FileBlame<CommitKey>>,
+    pub running_cohort_stats: HashMap<CommitKey, i64>,
+    pub commit_results: Vec<Vec<(CommitKey, i64)>>,
 }
 
 impl<CommitKey> RepositoryBlameSnapshot<CommitKey>
@@ -25,15 +26,16 @@ where
     pub fn new(commit_id: gix::ObjectId) -> Self {
         Self {
             commit_id,
-            file_blames: DashMap::new(),
-            running_cohort_stats: DashMap::new(),
+            file_blames: HashMap::new(),
+            running_cohort_stats: HashMap::new(),
+            commit_results: Vec::new(),
         }
     }
     pub fn set_commit_id(&mut self, commit_id: gix::ObjectId) {
         self.commit_id = commit_id;
     }
 
-    pub fn add_file(&self, path: &BString, total_lines: LineNumber, cohort: CommitKey) {
+    pub fn add_file(&mut self, path: &BString, total_lines: LineNumber, cohort: CommitKey) {
         let file_blame = FileBlame::new(total_lines, cohort);
         self.file_blames.insert(path.clone(), file_blame);
         self.running_cohort_stats
@@ -42,8 +44,8 @@ where
             .or_insert(total_lines as i64);
     }
 
-    pub fn delete_file(&self, path: &BString) {
-        if let Some((_, file_blame)) = self.file_blames.remove(path) {
+    pub fn delete_file(&mut self, path: &BString) {
+        if let Some(file_blame) = self.file_blames.remove(path) {
             for (cohort, line_count) in file_blame.cohort_stats() {
                 self.running_cohort_stats
                     .entry(cohort)
@@ -54,8 +56,8 @@ where
         }
     }
 
-    pub fn rename_file(&self, old_path: BString, new_path: BString) -> Result<(), String> {
-        let (_old_path, file_blame) = self
+    pub fn rename_file(&mut self, old_path: BString, new_path: BString) -> Result<(), String> {
+        let file_blame = self
             .file_blames
             .remove(&old_path)
             .ok_or_else(|| format!("File not found for rename: {:?}", old_path))?;
@@ -63,8 +65,8 @@ where
         Ok(())
     }
 
-    pub fn modify_file(&self, path: &BString, line_diffs: LineDiffs<CommitKey>) {
-        if let Some(mut file_blame) = self.file_blames.get_mut(path) {
+    pub fn modify_file(&mut self, path: &BString, line_diffs: LineDiffs<CommitKey>) {
+        if let Some(file_blame) = self.file_blames.get_mut(path) {
             let old_blame = file_blame.clone();
             let new_blame = old_blame.apply_line_diffs(line_diffs.clone());
             let mut cohort_diff: std::collections::HashMap<CommitKey, i64> =
@@ -87,13 +89,78 @@ where
             panic!("File not found for modify: {:?}", path);
         }
     }
+
+    pub fn handle_action(&mut self, action: Action<CommitKey>) {
+        match action {
+            Action::AddFile {
+                path,
+                total_lines,
+                cohort,
+            } => self.add_file(&path, total_lines, cohort),
+            Action::DeleteFile { path } => self.delete_file(&path),
+            Action::RenameFile { old_path, new_path } => {
+                self.rename_file(old_path, new_path).unwrap();
+            }
+            Action::ModifyFile { path, line_diffs } => self.modify_file(&path, line_diffs),
+            Action::FinishCommit => {
+                self.commit_results.push(self.repository_cohort_stats());
+            }
+            Action::SetCommitId(id) => {
+                self.set_commit_id(id);
+            }
+        }
+    }
     pub fn repository_cohort_stats(&self) -> Vec<(CommitKey, i64)>
     where
         CommitKey: Keyable,
     {
         self.running_cohort_stats
             .iter()
-            .map(|ref_multi| (*ref_multi.key(), *ref_multi.value()))
+            .map(|(k, v)| (*k, *v))
             .collect()
+    }
+}
+
+pub struct BlameProcessor<CommitKey>
+where
+    CommitKey: Keyable,
+{
+    sender: Sender<Action<CommitKey>>,
+    join_handle: Option<JoinHandle<RepositoryBlameSnapshot<CommitKey>>>,
+}
+
+impl<CommitKey> BlameProcessor<CommitKey>
+where
+    CommitKey: Keyable + Send + 'static,
+{
+    pub fn new(initial_commit_id: gix::ObjectId) -> Self {
+        let (sender, receiver) = unbounded();
+        let mut snapshot = RepositoryBlameSnapshot::new(initial_commit_id);
+
+        let join_handle = spawn(move || {
+            for action in receiver {
+                snapshot.handle_action(action);
+            }
+            snapshot
+        });
+
+        Self {
+            sender,
+            join_handle: Some(join_handle),
+        }
+    }
+
+    pub fn sender(&self) -> Sender<Action<CommitKey>> {
+        self.sender.clone()
+    }
+
+    pub fn finish(mut self) -> Vec<Vec<(CommitKey, i64)>> {
+        drop(self.sender);
+        self.join_handle
+            .take()
+            .unwrap()
+            .join()
+            .unwrap()
+            .commit_results
     }
 }


### PR DESCRIPTION
Previously, the RepositoryBlameSnapshot was a wrapper around a DashMap (multithreaded hashmap) that the worker threads would update. The map would point from filepath to "blame entry". 
Dashmap is a nice way for the worker threads to be able to update the map as they go along, but it can sometimes have lock contention on the shards of map.

This PR replaces it with a separate worker thread, changing the RepositoryBlameSnapshot to be owned by a BlameProcessor (probably could be combined now), which is communicated through a crossbeam channel. 

As the threads in the main rayon work pool go along processing commits and file diffs, they send the updates that need to be done to this BlameProcessor, instead of directly updating the Dashmap themselves. This has the potential to be slightly faster as it removes the Dashmap contention, and means the book-keeping is done in a separate thread.

This started mainly as an experiment but seems to have a ~10% boost so I'll keep it.

As a side effect, we also now handle entry mode changes (eg change `docs` from a directory to a file or vice versa) a little bit better, and the "business logic" we have to do it is a little more factored out into the separate `handle_file_modification`, `handle_entry_mode_change` etc functions.
