### PR TITLE
Improvements to uv and pipx running, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,46 +39,46 @@ gix-of-theseus stackplot cohorts.json
 ```
 
 # Caveats
+
 This tool is faster because it doesn't re-implement the full feature set of Git of Theseus. Notably it doesn't:
 
-* collect author information, or anything but the year of the commit
-* plot the "memory" graph of commits
-* The only behavior is `--all-filetypes`: there is no filtering to "only source code files". This is coming but not a big priority.
+- collect author information, or plot anything but the year of the commit
+- plot the "forgetting curve" of commits
+- The only behavior is `--all-filetypes`: there is no filtering to "only source code files". This is coming but not a big priority.
 
 I plan on implementing some of these features, but they are not present yet. I don't find the author information valuable so I place a low priority on plotting it, "PRs welcome" if you really want it.
 
 Another important caveat:
-*  `.git-rev-ignore` files are not supported. 
 
-As this is a custom blame implementation, several git features are not supported. Some of these can be filled in, but this tool is currently useful atm for a lot of repos and this doesn't seem to be a major issue.
+- `.git-rev-ignore` files are not supported.
 
+As this is a custom blame implementation, several git-specific features like `.git-rev-ignore` files (also mailmaps) are not supported. Some of these can be filled in, but this tool is currently useful atm for a lot of repos and this doesn't seem to be a major issue.
 
 The stackplots generated are not 100% identical with the original's output. I would say they are 98% the same, which is fine for this type of analysis.
 
 #### Some speed comparison for fun
 
-This is just for fun, to make the author feel good that they didn't waste all this time Rewriting It In Rust.
+This is just for fun, to make this author feel good that they didn't waste all this time Rewriting It In Rust.
 
 These are rough measurements using `time` on a M1 Max laptop, not real benchmarks. When Git of Theseus was taking too long for to wait, I gave the ETA displayed in the progress bar (after waiting for it to stabilize) and marked that result with a `~`.
 
+| Repo                  | Original [s] | This repo [s] | Speedup |
+| :-------------------- | -----------: | ------------: | ------: |
+| torvalds/linux        |       ~36000 |            58 |   ~620x |
+| ffmepg/ffmepg         |         8195 |           7.8 |   1050x |
+| golang/go             |        ~3780 |           7.0 |   ~540x |
+| grpc/grpc             |        ~3600 |           7.4 |   ~486x |
+| git/git               |        ~2460 |           5.1 |   ~480x |
+| apache/spark          |        ~1800 |           6.5 |   ~277x |
+| elastic/elasticsearch |              |           7.0 |
+| bazelbuild/bazel      |              |           7.0 |
+| apache/echarts        |              |           7.2 |
 
-| Repo | Original [s] | This repo [s] | Speedup |
-|:---|---:|---:|---:|
-torvalds/linux  | ~36000 | 58 | ~620x
-ffmepg/ffmepg |  8195 | 7.8 | 1050x
-golang/go | ~3780 | 7.0 | ~540x
-grpc/grpc | ~ 3600 | 7.4 | ~486x
-git/git | ~2460 | 5.1 | ~480x
-apache/spark | ~1800| 6.5 | ~277x
-elastic/elasticsearch | | 7.0 | 
-bazelbuild/bazel | | 7.0 | 
-apache/echarts | | 7.2 | 
-BurntSushi/ripgrep| 15.8 | 1.4 | 11.3x
 ---
 
-* git-of-theseus was run with --procs 15 (seems a little IO bound on this machine) and with the --all-filetypes flag, to match this project's behavior.
+- git-of-theseus was run with --procs 15 (seems a little IO bound on this machine) and with the --all-filetypes flag, to match this project's behavior.
 
-The (geometric) mean of the speedups is ~285x, though this is completely dependent on your sample, as the gap is much larger in huge, old repos.
-This sample contains more of those, though it's somewhat defensible as these repos are the ones that benefit the most from these types of graphs. Whereas you don't really see a "Ship of Theseus" when running it on a personal side project that's 2 years old.
+The speedup on these large repos is conservatively ~300x, though the gap is larger in huge, old repos.
+This sample contains more of those, as these repos are the ones which benefit the most from a theseus graph. You don't get much insight when running it on a small, young repo.
 
 I speculate that the runtime (and the speedup) is more related to total volume of code (SLOC) in a repo, though theoretically the main improvement should be making it linear in the number of commits instead of quadratic.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,29 @@ uv run src/stackplot.py cohorts.json
 gix-of-theseus stackplot cohorts.json
 ```
 
-#### Some speed comparison
+# Caveats
+This tool is faster because it doesn't re-implement the full feature set of Git of Theseus. Notably it doesn't:
 
-This is just for fun, to make the author feel good that they didn't waste all this time Rewriting It In Rust for nothing.
+* collect author information, or anything but the year of the commit
+* plot the "memory" graph of commits
+* The only behavior is `--all-filetypes`: there is no filtering to "only source code files". This is coming but not a big priority.
 
-These are rough measurements using `time` on a M1 Max laptop, not real benchamrks.
+I plan on implementing some of these features, but they are not present yet. I don't find the author information valuable so I place a low priority on plotting it, "PRs welcome" if you really want it.
 
-When Git of Theseus was taking too long for me to wait, I gave the ETA displayed in the progress bar (after waiting for it to stabilize) and marked that result with a `~`.
+Another important caveat:
+*  `.git-rev-ignore` files are not supported. 
+
+As this is a custom blame implementation, several git features are not supported. Some of these can be filled in, but this tool is currently useful atm for a lot of repos and this doesn't seem to be a major issue.
+
+
+The stackplots generated are not 100% identical with the original's output. I would say they are 98% the same, which is fine for this type of analysis.
+
+#### Some speed comparison for fun
+
+This is just for fun, to make the author feel good that they didn't waste all this time Rewriting It In Rust.
+
+These are rough measurements using `time` on a M1 Max laptop, not real benchmarks. When Git of Theseus was taking too long for to wait, I gave the ETA displayed in the progress bar (after waiting for it to stabilize) and marked that result with a `~`.
+
 
 | Repo | Original [s] | This repo [s] | Speedup |
 |:---|---:|---:|---:|
@@ -62,8 +78,7 @@ BurntSushi/ripgrep| 15.8 | 1.4 | 11.3x
 
 * git-of-theseus was run with --procs 15 (seems a little IO bound on this machine) and with the --all-filetypes flag, to match this project's behavior.
 
-The (geometric) mean of the speedups is ~285x, though this is completely dependent on your sample, as the gap is much larger in huge old repos.
-This is measured on large repos, though it's somewhat defensible to do so as these are the ones that benefit the most from these types of graphs,
-and that have the nicest looking ones. Whereas you don't really, see a "Ship of Theseus" when running this on a personal side project that's 2 years old.
+The (geometric) mean of the speedups is ~285x, though this is completely dependent on your sample, as the gap is much larger in huge, old repos.
+This sample contains more of those, though it's somewhat defensible as these repos are the ones that benefit the most from these types of graphs. Whereas you don't really see a "Ship of Theseus" when running it on a personal side project that's 2 years old.
 
 I speculate that the runtime (and the speedup) is more related to total volume of code (SLOC) in a repo, though theoretically the main improvement should be making it linear in the number of commits instead of quadratic.

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -1,27 +1,64 @@
 use anyhow::Result;
 use std::io::Write;
 use std::process::Command;
+use std::sync::OnceLock;
 use std::{env, fs};
 
 const STACKPLOT_SCRIPT: &str = include_str!("stackplot.py");
 
+static PYTHON_SCRIPT_RUNNER: OnceLock<Option<String>> = OnceLock::new();
+
+pub fn get_python_runner() -> Option<String> {
+    PYTHON_SCRIPT_RUNNER
+        .get_or_init(|| {
+            let runners = ["uv", "pipx"];
+
+            for runner in runners {
+                if Command::new(runner)
+                    .arg("--version")
+                    .output()
+                    .map(|output| output.status.success())
+                    .unwrap_or(false)
+                {
+                    return Some(runner.to_string());
+                }
+            }
+
+            None
+        })
+        .clone()
+}
 pub fn run_stackplot(input_file: String, output_file: String) -> Result<()> {
+    let runner = get_python_runner().ok_or_else(|| anyhow::anyhow!("No Python runner found"))?;
+
     let mut path = env::temp_dir();
     path.push("stackplot.py");
 
     let mut file = fs::File::create(&path)?;
     file.write_all(STACKPLOT_SCRIPT.as_bytes())?;
 
-    let status = Command::new("uv")
-        .arg("run")
-        .arg(&path)
-        .arg("--outfile")
-        .arg(output_file)
-        .arg(input_file)
-        .status()?;
+    let status = if runner == "uv" {
+        Command::new(&runner)
+            .arg("run")
+            .arg(&path)
+            .arg("--outfile")
+            .arg(output_file)
+            .arg(input_file)
+            .status()?
+    } else if runner == "pipx" {
+        Command::new(&runner)
+            .arg("run")
+            .arg(&path)
+            .arg("--outfile")
+            .arg(output_file)
+            .arg(input_file)
+            .status()?
+    } else {
+        anyhow::bail!("Unsupported runner: {}", runner);
+    };
 
     if !status.success() {
-        anyhow::bail!("Failed to execute 'uv run {}'", path.display());
+        anyhow::bail!("Failed to execute '{} run {}'", runner, path.display());
     }
 
     fs::remove_file(path)?;

--- a/src/stackplot.py
+++ b/src/stackplot.py
@@ -82,7 +82,7 @@ def stack_plot(
         pyplot.ylim([0, 100])
     else:
         pyplot.ylabel("Lines of code")
-    print(f"Writing output to {outfile}")
+    print(f"Writing stackplot image to {outfile}")
     pyplot.savefig(outfile)
     pyplot.tight_layout()
     if display:


### PR DESCRIPTION
* Changes some default settings for the output files, which now go to:
`$outdir/cohorts.json` and `$outdir/stackplot.png`, where `$outdir` defaults to the repo directory name (eg `for $home/repos/facebook/react` it defaults to `react`)
* Defaults to plotting an image in the `analyze` subcommand (turn off with `--no-plot`), but checks if `uv` or `pipx` is installed first
* Updates to the readme